### PR TITLE
Update test_receive_record_basic

### DIFF
--- a/lab-06/tests/test_tinyssl_client.py
+++ b/lab-06/tests/test_tinyssl_client.py
@@ -20,8 +20,8 @@ class RecordFormatTestCase(unittest.TestCase):
                          "Length of data does not match header")
 
     def test_receive_record_basic(self):
-        expected = b'\x80\x18This is yet another test'
-        test_data = 'This is yet another test'.encode()
+        test_data = b'\x80\x18This is yet another test'
+        expected = 'This is yet another test'.encode()
         result = self.tsclient.decode_record(test_data)
         self.assertEqual(result, expected,
                          "Unexpected data")


### PR DESCRIPTION
I believe we are supposed to feed the record into tsclient.decode_record(), but this test case feeds the expected output